### PR TITLE
Feature/add id to msg def

### DIFF
--- a/plugin/action_test.go
+++ b/plugin/action_test.go
@@ -9,6 +9,7 @@ import (
 
 var actionStartMessage = `
 {
+  "id": "id123",
   "version": "v1",
   "type": "action_start",
   "body": {
@@ -24,6 +25,7 @@ var actionStartMessage = `
 
 var invalidTypeActionStartMessage = `
 {
+  "id": "id123",
   "version": "v1",
   "type": "not_action_start",
   "body": {
@@ -90,16 +92,16 @@ func (h *HelloAction) Act() error {
 
 func TestWorkingAction(t *testing.T) {
 	parameter.Stdin = parameter.NewParamSet(strings.NewReader(actionStartMessage))
-	expectedOutputEvent := `{"version":"v1","type":"action_event","body":{"meta":{"action_id":14},"status":"ok","error":"","output":{"greeting":"good day to you"}}}`
+	expectedOutputEvent := `{"id":"","version":"v1","type":"action_event","body":{"meta":{"action_id":14},"status":"ok","error":"","output":{"greeting":"good day to you"}}}`
 	dispatcher := &mockDispatcher{}
 
 	// mock dispatcher to test dispatch works
 	defaultActionDispatcher = dispatcher
 
 	p := New()
-	err := p.Run()
-	if err != nil {
-		t.Fatalf("Unable to run %s: %v", p.Name, err)
+
+	if err := p.Run(); err != nil {
+		t.Fatalf("Unable to run %s: %v", p.Name(), err)
 	}
 
 	if dispatcher.result != expectedOutputEvent {
@@ -126,6 +128,7 @@ func TestGenerateSampleActionStartMessage(t *testing.T) {
 	action := &HelloAction{}
 
 	sample := `{
+   "id": "id123",
    "version": "v1",
    "type": "action_start",
    "body": {

--- a/plugin/cli.go
+++ b/plugin/cli.go
@@ -106,8 +106,8 @@ func (c *cli) Run() {
 	args, err := app.Parse(c.Args)
 
 	if *debug {
-		if debuggable, ok := plugin.(debuggable); ok {
-			debuggable.SetDebug()
+		if dbgable, ok := plugin.(debuggable); ok {
+			dbgable.SetDebug()
 		}
 	}
 

--- a/plugin/dispatch.go
+++ b/plugin/dispatch.go
@@ -71,7 +71,7 @@ func (d *HTTPDispatcher) Send(event *message.Message) error {
 	req, err := http.NewRequest("POST", d.URL, bytes.NewBuffer(messageBytes))
 
 	if err != nil {
-		err := fmt.Errorf("Unable to POST to dispatcher: %+v", err)
+		err = fmt.Errorf("Unable to POST to dispatcher: %+v", err)
 		return err
 	}
 
@@ -79,7 +79,7 @@ func (d *HTTPDispatcher) Send(event *message.Message) error {
 
 	resp, err := d.client.Do(req)
 	if err != nil {
-		err := fmt.Errorf("Unable to send event to http dispatcher: %+v", err)
+		err = fmt.Errorf("Unable to send event to http dispatcher: %+v", err)
 		return err
 	}
 	defer resp.Body.Close()

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -26,6 +26,7 @@ func GenerateSampleActionStart(action Actionable) (string, error) {
 
 	env := message.Message{
 		Header: message.Header{
+			ID:      "id123",
 			Version: message.Version,
 			Type:    ActionStart,
 		},
@@ -62,6 +63,7 @@ func GenerateSampleTriggerStart(trigger Triggerable) (string, error) {
 
 	env := message.Message{
 		Header: message.Header{
+			ID:      "id123",
 			Version: message.Version,
 			Type:    TriggerStart,
 		},

--- a/plugin/message/header.go
+++ b/plugin/message/header.go
@@ -2,6 +2,7 @@ package message
 
 // Header is appended to the top of every message
 type Header struct {
+	ID      string `json:"id"`      // Application level identifier for the message, intended to be a UUID
 	Version string `json:"version"` // version of messages
 	Type    string `json:"type"`    // message type
 }

--- a/plugin/message/trigger_test.go
+++ b/plugin/message/trigger_test.go
@@ -46,8 +46,7 @@ func TestMarshalTriggerStartWithMessageEnvelope(t *testing.T) {
 	}
 
 	trig := &TriggerStart{
-		TriggerID: 1,
-		Trigger:   "hello",
+		Trigger: "hello",
 		startMessage: startMessage{
 			Connection: conn,
 			Dispatcher: dispatcher,
@@ -114,8 +113,7 @@ func TestMarshalTriggerStart(t *testing.T) {
 	}
 
 	trig := &TriggerStart{
-		TriggerID: 1,
-		Trigger:   "hello",
+		Trigger: "hello",
 		startMessage: startMessage{
 			Connection: conn,
 			Dispatcher: dispatcher,

--- a/plugin/message/trigger_test.go
+++ b/plugin/message/trigger_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMarshalTriggerStartWithMessageEnvelope(t *testing.T) {
 
-	expected := `{"version":"v1","type":"trigger_start","body":{"trigger_id":1,"trigger":"hello","connection":{"username":"hello","password":"blah"},"dispatcher":{"url":"http://abc123"},"input":{"param":"ok","param2":"blah"}}}`
+	expected := `{"id":"id123","version":"v1","type":"trigger_start","body":{"trigger_id":1,"trigger":"hello","connection":{"username":"hello","password":"blah"},"dispatcher":{"url":"http://abc123"},"input":{"param":"ok","param2":"blah"}}}`
 
 	connJSON := `
 	{
@@ -56,6 +56,7 @@ func TestMarshalTriggerStartWithMessageEnvelope(t *testing.T) {
 
 	m := Message{
 		Header: Header{
+			ID:      "id123",
 			Version: "v1",
 			Type:    "trigger_start",
 		},

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -145,22 +145,22 @@ func (p *Plugin) setup() (task, error) {
 
 // Run runs a Plugin
 func (p *Plugin) Run() error {
-	task, err := p.setup()
+	t, err := p.setup()
 
 	if err != nil {
 		return err
 	}
-	return task.Run()
+	return t.Run()
 }
 
 // Test tests a Plugin
 func (p *Plugin) Test() error {
-	task, err := p.setup()
+	t, err := p.setup()
 
 	if err != nil {
 		return err
 	}
-	return task.Test()
+	return t.Test()
 }
 
 // AddTrigger adds triggers to the map of Plugins triggers

--- a/plugin/trigger_task.go
+++ b/plugin/trigger_task.go
@@ -137,14 +137,14 @@ type triggerEventCollector struct {
 }
 
 func makeTriggerEventCollector(message *message.TriggerStart, trigger Triggerable, dispatcher Dispatcher) (*triggerEventCollector, error) {
-	if queueable, ok := trigger.(queueable); ok {
+	if q, ok := trigger.(queueable); ok {
 
-		queueable.InitQueue()
+		q.InitQueue()
 
 		return &triggerEventCollector{
 			message:    message,
 			stopped:    make(chan bool, 1),
-			sender:     queueable,
+			sender:     q,
 			dispatcher: dispatcher,
 		}, nil
 	}

--- a/plugin/trigger_test.go
+++ b/plugin/trigger_test.go
@@ -12,6 +12,7 @@ import (
 
 var triggerTestStartMessage = `
 {
+	"id":"id123",
   "version": "v1",
   "type": "trigger_start",
   "body": {
@@ -28,6 +29,7 @@ var triggerTestStartMessage = `
 
 var triggerStartMessage = `
 {
+	"id":"id123",
   "version": "v1",
   "type": "trigger_start",
   "body": {
@@ -45,6 +47,7 @@ var triggerStartMessage = `
 
 var invalidTypeTriggerStartMessage = `
 {
+	"id":"id123",
   "version": "v1",
   "type": "not_trigger_start",
   "body": {
@@ -136,7 +139,7 @@ func TestWorkingTrigger(t *testing.T) {
 
 	trigger := &HelloTrigger{}
 
-	expectedOutputEvent := `{"version":"v1","type":"trigger_event","body":{"meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
+	expectedOutputEvent := `{"id":"","version":"v1","type":"trigger_event","body":{"meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
 	parameter.Stdin = parameter.NewParamSet(strings.NewReader(triggerStartMessage))
 
 	dispatcher := &mockDispatcher{}
@@ -157,7 +160,7 @@ func TestWorkingTrigger(t *testing.T) {
 	err := p.Run()
 
 	if err != nil {
-		t.Fatalf("Unable to run %s: %v", p.Name, err)
+		t.Fatalf("Unable to run %s: %v", p.Name(), err)
 	}
 
 	if trigger.input.Person != "Bob" {
@@ -239,7 +242,7 @@ func TestRunPluginTriggerWithTestRunsTest(t *testing.T) {
 	err := p.Test()
 
 	if err != nil {
-		t.Fatalf("Unable to test %s: %v", p.Name, err)
+		t.Fatalf("Unable to test %s: %v", p.Name(), err)
 	}
 
 	if trigger.testRan != true {
@@ -270,7 +273,7 @@ func TestRunPluginTriggerWithoutTestDoesNothing(t *testing.T) {
 	err := p.Test()
 
 	if err != nil {
-		t.Fatalf("Unable to test %s: %v", p.Name, err)
+		t.Fatalf("Unable to test %s: %v", p.Name(), err)
 	}
 
 	if trigger.testRan != false {
@@ -351,6 +354,7 @@ func TestBadConnectionWillFailTest(t *testing.T) {
 }
 
 var sampleMsg = `{
+   "id": "id123",
    "version": "v1",
    "type": "trigger_start",
    "body": {
@@ -383,7 +387,7 @@ func TestGenerateSampleTriggerStartMessage(t *testing.T) {
 
 	p, _ := GenerateSampleTriggerStart(trigger)
 	if p != sampleMsg {
-		t.Fatal("Expected trigger start to be equal: %s, %s", p, sampleMsg)
+		t.Fatalf("Expected trigger start to be equal: %s, %s", p, sampleMsg)
 	}
 
 }


### PR DESCRIPTION
ping @jandre @rossnanop @jcsalem 

This adds an ID field to the Header so that we can add an application level ID to messages which we can use in the engine/web so people can track the status of a job as it moves around.

We likely want to make the same sets of changes to the Python message definition as well.

Sister PR into Komand/Komand here: https://github.com/komand/komand/pull/457

Additionally, I did some minor cleanup to get rid of some nagging by golint/govet.

Longer term I have some thoughts on how to redesign parts of this to improve some of the tests and build more of a single pipeline for creating and dealing with messages, but those aren't really salient at this time.