### PR TITLE
Moving the ID for tracking the job request from the message itself on…

### DIFF
--- a/plugin/action_test.go
+++ b/plugin/action_test.go
@@ -9,7 +9,6 @@ import (
 
 var actionStartMessage = `
 {
-  "id": "id123",
   "version": "v1",
   "type": "action_start",
   "body": {
@@ -25,7 +24,6 @@ var actionStartMessage = `
 
 var invalidTypeActionStartMessage = `
 {
-  "id": "id123",
   "version": "v1",
   "type": "not_action_start",
   "body": {
@@ -92,7 +90,7 @@ func (h *HelloAction) Act() error {
 
 func TestWorkingAction(t *testing.T) {
 	parameter.Stdin = parameter.NewParamSet(strings.NewReader(actionStartMessage))
-	expectedOutputEvent := `{"id":"","version":"v1","type":"action_event","body":{"meta":{"action_id":14},"status":"ok","error":"","output":{"greeting":"good day to you"}}}`
+	expectedOutputEvent := `{"version":"v1","type":"action_event","body":{"meta":{"action_id":14},"status":"ok","error":"","output":{"greeting":"good day to you"}}}`
 	dispatcher := &mockDispatcher{}
 
 	// mock dispatcher to test dispatch works
@@ -128,7 +126,6 @@ func TestGenerateSampleActionStartMessage(t *testing.T) {
 	action := &HelloAction{}
 
 	sample := `{
-   "id": "id123",
    "version": "v1",
    "type": "action_start",
    "body": {

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -26,7 +26,6 @@ func GenerateSampleActionStart(action Actionable) (string, error) {
 
 	env := message.Message{
 		Header: message.Header{
-			ID:      "id123",
 			Version: message.Version,
 			Type:    ActionStart,
 		},
@@ -63,7 +62,6 @@ func GenerateSampleTriggerStart(trigger Triggerable) (string, error) {
 
 	env := message.Message{
 		Header: message.Header{
-			ID:      "id123",
 			Version: message.Version,
 			Type:    TriggerStart,
 		},

--- a/plugin/message/header.go
+++ b/plugin/message/header.go
@@ -2,7 +2,6 @@ package message
 
 // Header is appended to the top of every message
 type Header struct {
-	ID      string `json:"id"`      // Application level identifier for the message, intended to be a UUID
 	Version string `json:"version"` // version of messages
 	Type    string `json:"type"`    // message type
 }

--- a/plugin/message/trigger.go
+++ b/plugin/message/trigger.go
@@ -11,6 +11,7 @@ type TriggerStart struct {
 
 // TriggerEvent messages encapsulate any output event emitted by the plugins.
 type TriggerEvent struct {
+	ID     string           `json:"id"` // Application level identifier for the TriggerEvent for later tracking via the UI
 	Meta   *json.RawMessage `json:"meta"`
 	Output OutputMessage    `json:"output"`
 }

--- a/plugin/message/trigger_test.go
+++ b/plugin/message/trigger_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMarshalTriggerStartWithMessageEnvelope(t *testing.T) {
 
-	expected := `{"id":"id123","version":"v1","type":"trigger_start","body":{"trigger_id":1,"trigger":"hello","connection":{"username":"hello","password":"blah"},"dispatcher":{"url":"http://abc123"},"input":{"param":"ok","param2":"blah"}}}`
+	expected := `{"version":"v1","type":"trigger_start","body":{"trigger_id":1,"trigger":"hello","connection":{"username":"hello","password":"blah"},"dispatcher":{"url":"http://abc123"},"input":{"param":"ok","param2":"blah"}}}`
 
 	connJSON := `
 	{
@@ -56,7 +56,6 @@ func TestMarshalTriggerStartWithMessageEnvelope(t *testing.T) {
 
 	m := Message{
 		Header: Header{
-			ID:      "id123",
 			Version: "v1",
 			Type:    "trigger_start",
 		},

--- a/plugin/trigger_test.go
+++ b/plugin/trigger_test.go
@@ -12,7 +12,6 @@ import (
 
 var triggerTestStartMessage = `
 {
-	"id":"id123",
   "version": "v1",
   "type": "trigger_start",
   "body": {
@@ -29,7 +28,6 @@ var triggerTestStartMessage = `
 
 var triggerStartMessage = `
 {
-	"id":"id123",
   "version": "v1",
   "type": "trigger_start",
   "body": {
@@ -47,7 +45,6 @@ var triggerStartMessage = `
 
 var invalidTypeTriggerStartMessage = `
 {
-	"id":"id123",
   "version": "v1",
   "type": "not_trigger_start",
   "body": {
@@ -139,7 +136,7 @@ func TestWorkingTrigger(t *testing.T) {
 
 	trigger := &HelloTrigger{}
 
-	expectedOutputEvent := `{"id":"","version":"v1","type":"trigger_event","body":{"meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
+	expectedOutputEvent := `{"version":"v1","type":"trigger_event","body":{"id":"","meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
 	parameter.Stdin = parameter.NewParamSet(strings.NewReader(triggerStartMessage))
 
 	dispatcher := &mockDispatcher{}
@@ -354,7 +351,6 @@ func TestBadConnectionWillFailTest(t *testing.T) {
 }
 
 var sampleMsg = `{
-   "id": "id123",
    "version": "v1",
    "type": "trigger_start",
    "body": {


### PR DESCRIPTION
…to the trigger event

ping @jcsalem 

This moves the ID from Message Header to TriggerEvent, which we reference from Komand Prime.