### PR TITLE
GroupID

### DIFF
--- a/plugin/message/trigger.go
+++ b/plugin/message/trigger.go
@@ -11,7 +11,8 @@ type TriggerStart struct {
 
 // TriggerEvent messages encapsulate any output event emitted by the plugins.
 type TriggerEvent struct {
-	ID     string           `json:"id"` // Application level identifier for the TriggerEvent for later tracking via the UI
-	Meta   *json.RawMessage `json:"meta"`
-	Output OutputMessage    `json:"output"`
+	ID      string           `json:"id"`       // Application level identifier for the TriggerEvent for later tracking via the UI
+	GroupID string           `json:"group_id"` // Another application level id, this one is used internally to allow us to re-publish a job and track them under a common ID
+	Meta    *json.RawMessage `json:"meta"`
+	Output  OutputMessage    `json:"output"`
 }

--- a/plugin/trigger_test.go
+++ b/plugin/trigger_test.go
@@ -136,7 +136,7 @@ func TestWorkingTrigger(t *testing.T) {
 
 	trigger := &HelloTrigger{}
 
-	expectedOutputEvent := `{"version":"v1","type":"trigger_event","body":{"id":"","meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
+	expectedOutputEvent := `{"version":"v1","type":"trigger_event","body":{"id":"","group_id":"","meta":{"channel":"xyz-abc-123"},"output":{"Goodbye":"bob"}}}`
 	parameter.Stdin = parameter.NewParamSet(strings.NewReader(triggerStartMessage))
 
 	dispatcher := &mockDispatcher{}


### PR DESCRIPTION
ping @jandre 

So if we go with group id (which I'm largely in favor of cus it simplifies a lot of things), we need to update the SDK unfortunately. We make use of this type in the main repo as well.